### PR TITLE
Use field.widget.settings.number as base for field.widget.settings.unlimited_number schema.

### DIFF
--- a/config/schema/unlimited_number.schema.yml
+++ b/config/schema/unlimited_number.schema.yml
@@ -1,5 +1,5 @@
 field.widget.settings.unlimited_number:
-  type: mapping
+  type: field.widget.settings.number
   label: 'Unlimited number settings'
   mapping:
     value_unlimited:
@@ -11,6 +11,3 @@ field.widget.settings.unlimited_number:
     label_number:
       type: string
       label: 'Limited Label'
-    placeholder:
-      type: label
-      label: 'Placeholder'


### PR DESCRIPTION
This follows https://www.drupal.org/node/2816859, inheriting the expanded number field base config to keep schema definition complete for fields instantiated with the patch from that issue.